### PR TITLE
Give flexibility install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,22 +52,22 @@ dp_description = 'MVC Web Application Framework with Tornado.'
 
 
 install_requires = [
-        'BeautifulSoup4==4.7.1',
-        'boto3==1.9.111',
-        'croniter==0.3.27',
-        'CyMySQL==0.9.13',
-        'httpagentparser==1.8.2',
-        'lxml==4.3.2',
-        'Pillow==5.4.1',
-        'pycrypto==2.6.1',
-        'pytz==2018.9',
-        'redis==3.2.0',
-        'requests==2.21.0',
-        'SQLAlchemy==1.3.1',
-        'tornado==4.5.3',
-        'validate_email==1.3',
-        'validators==0.12.4',
-        'wand==0.5.1',
+        'BeautifulSoup4>=4.7.1',
+        'boto3>=1.9.111',
+        'croniter>=0.3.30',
+        'CyMySQL>=0.9.13',
+        'httpagentparser>=1.8.2',
+        'lxml>=4.3.2',
+        'Pillow>=5.4.1',
+        'pycrypto>=2.6.1',
+        'pytz>=2018.9',
+        'redis>=3.2.0',
+        'requests>=2.21.0',
+        'SQLAlchemy>=1.3.1',
+        'tornado>=4.5.3,<5.0.0',
+        'validate_email>=1.3',
+        'validators>=0.12.4',
+        'wand>=0.5.1',
         # , 'selenium'
     ]
 


### PR DESCRIPTION
Additionally, install requirements `crontier==0.3.27` was deleted from pypi

```
Collecting croniter==0.3.27 (from dp-tornado==0.9.4.18->-r requirements.txt (line 1))
  Could not find a version that satisfies the requirement croniter==0.3.27 (from dp-tornado==0.9.4.18->-r requirements.txt (line 1)) (from versions: 0.1.4.macosx-10.5-i386, 0.1.1, 0.1.2, 0.1.3, 0.1.4, 0.1.5, 0.1.6, 0.2.0, 0.2.2, 0.2.4, 0.2.5, 0.2.7, 0.3.0, 0.3.1, 0.3.2, 0.3.3, 0.3.4, 0.3.5, 0.3.6, 0.3.7, 0.3.8, 0.3.9, 0.3.10, 0.3.11, 0.3.12, 0.3.13, 0.3.14, 0.3.15, 0.3.16, 0.3.17, 0.3.18, 0.3.19, 0.3.20, 0.3.22, 0.3.23, 0.3.24, 0.3.25, 0.3.28, 0.3.29, 0.3.30)
```