### PR TITLE
s3 filename encode when generate presigned url

### DIFF
--- a/dp_tornado/helper/web/aws/s3.py
+++ b/dp_tornado/helper/web/aws/s3.py
@@ -229,8 +229,9 @@ class S3Helper(dpHelper):
             'get_object',
             Params={'Bucket': bucket_name,
                     'Key': key,
-                    'ResponseContentDisposition': 'attachment; filename=%s' % file_name},
-                    ExpiresIn=expires_in)
+                    'ResponseContentDisposition': 'attachment; filename=%s' % (
+                        self.helper.web.url.encode(file_name))},
+            ExpiresIn=expires_in)
 
     def generate_presigned_post(self,
                                 access_key_id,


### PR DESCRIPTION
- fix indent
- encode filename (cannot be represented using iso-8859-1 in header value)